### PR TITLE
Fix failing spec

### DIFF
--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe Types::QueryType do
     end
 
     it "returns all items" do
-      expect(result.dig("data", "items")).to match_array(
-        items.map { |item| { "title" => item.title } }
-      )
+      expect(result.dig("data", "items").map{ |item| item["title"] })
+        .to match_array(items.map(&:title))
     end
   end
 end


### PR DESCRIPTION
I could swear this worked after the first part of the guide. But now, it's failing with the following error:

```ruby
> be rspec
F

Failures:

  1) Types::QueryType items returns all items
     Failure/Error:
       expect(result.dig('data', 'items')).to match_array(
         items.map { |item| { 'title' => item.title } }
       )

       expected collection contained:  [{"title"=>"item-1"}, {"title"=>"item-2"}]
       actual collection contained:    [{"title"=>"item-1", "user"=>{"fullName"=>""}}, {"title"=>"item-2", "user"=>{"fullName"=>""}}]
       the missing elements were:      [{"title"=>"item-1"}, {"title"=>"item-2"}]
       the extra elements were:        [{"title"=>"item-1", "user"=>{"fullName"=>""}}, {"title"=>"item-2", "user"=>{"fullName"=>""}}]
     # ./spec/graphql/types/query_type_spec.rb:22:in `block (3 levels) in <top (required)>'

Finished in 0.06496 seconds (files took 0.86266 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/graphql/types/query_type_spec.rb:17 # Types::QueryType items returns all items
```

I checked out the commit when i first added the specs and the spec still failed.

Anyways, here's the simplest fix I could think of.