### PR TITLE
Fixed error with email variable in signIn mutation

### DIFF
--- a/app/javascript/components/UserInfo/operations.graphql
+++ b/app/javascript/components/UserInfo/operations.graphql
@@ -8,7 +8,7 @@ query Me {
 }
 
 mutation SignMeIn($email: String!) {
-  signIn(email: $email) {
+  signIn(input: { email: $email }) {
     token
     user {
       id


### PR DESCRIPTION
Hello,

First of all, I am really enjoying this tutorial. It's easy to read and follow, and having the complete repo as a reference is very helpful. While working through Part 2, I ran into an issue with the `signIn` mutation. I followed along and implemented everything correctly, but I kept seeing this error:
```{
  "errors": [
    {
      "message": "Field 'signIn' is missing required arguments: input",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "mutation SignMeIn",
        "signIn"
      ],
      "extensions": {
        "code": "missingRequiredArguments",
        "className": "Field",
        "name": "signIn",
        "arguments": "input"
      }
    },
    {
      "message": "Field 'signIn' doesn't accept argument 'email'",
      "locations": [
        {
          "line": 2,
          "column": 10
        }
      ],
      "path": [
        "mutation SignMeIn",
        "signIn",
        "email"
      ],
      "extensions": {
        "code": "argumentNotAccepted",
        "name": "signIn",
        "typeName": "Field",
        "argumentName": "email"
      }
    },
    {
      "message": "Variable $email is declared by SignMeIn but not used",
      "locations": [
        {
          "line": 1,
          "column": 1
        }
      ],
      "path": [
        "mutation SignMeIn"
      ],
      "extensions": {
        "code": "variableNotUsed",
        "variableName": "email"
      }
    }
  ]
}
```
It took me a few hours, and I finally went into GraphiQL (this is my first time using GraphQL, so the tools are new to me) to test out the mutation. I noticed that `signIn(email:` on the second line was underlined in red. I hovered over and saw these two messages: `Field "signIn" argument "input" of type "SignInMutationInput!" is required but not provided."` (**signIn**), `Unknown argument "email" on field "signIn" of type "Mutation".` (**email:**). 

I changed line 2 as you can see in the PR, and the error message went away. I went back into the development app and tried it out and it worked. 

I hope this helps!